### PR TITLE
fixing issue #3; specify callback uri as 'oob' explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Install the module with: `npm install twitter-pin-auth`
 
 ```javascript
 var TwitterPinAuth = require('twitter-pin-auth');
-var twitterPinAuth = new TwitterPinAuth('consumerKey', 'consumerSecret');
+var twitterPinAuth = new TwitterPinAuth('consumerKey', 'consumerSecret', 'screen_name_that_will_prefilled', false); // <- Use Force login with user that alrealy logged in
 ```
 
 ## Documentation

--- a/lib/twitter-pin-auth.js
+++ b/lib/twitter-pin-auth.js
@@ -45,7 +45,7 @@ var TwitterPinAuth = module.exports = function TwitterPinAuth(consumerKey, consu
     this.consumerSecret = consumerSecret;
     this._data = {};
     //Instance
-    this.oa = new OAuth(this.REQUEST_TOKEN_URL, this.ACCESS_TOKEN_URL, consumerKey, consumerSecret, this.OAUTH_VERSION, null, this.HASH_VERSION);
+    this.oa = new OAuth(this.REQUEST_TOKEN_URL, this.ACCESS_TOKEN_URL, consumerKey, consumerSecret, this.OAUTH_VERSION, 'oob', this.HASH_VERSION);
 };
 
 /*


### PR DESCRIPTION
As title, specify callback URI as 'oob' instead of null, explicitly.
